### PR TITLE
Switched upstream merge to main release branch from working dev branch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ merge_upstream: &merge_upstream
         command: |
           git config --global user.email "sws-developers@lists.stanford.edu"
           git config --global user.name "CircleCI"
-          git pull https://github.com/SU-SWS/stanford_profile.git 8.x-2.x -X ours --no-edit
+          git pull https://github.com/SU-SWS/stanford_profile.git main -X ours --no-edit
           if [[ $(git diff origin/${CIRCLE_BRANCH} --name-only) ]]; then
             DATE=`date +%Y-%m-%d`
             git checkout -b ${DATE}


### PR DESCRIPTION
# READY FOR REVIEW


# Summary
- Changed automated upstream merge from `stanford_profile` to pull from the `main` release branch instead of the working dev branch
- Goal is to decrease the frequency of upstream updates and amount of PR's since this profile is no longer in active development


# Urgency
Low